### PR TITLE
The search filters are now saved on info page and back

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -192,7 +192,6 @@ export default {
     async initialize() {
       const baseUrl = "https://api.themoviedb.org/3";
 
-      // Sequential requests
       this.newMovies = await this.fetchCategory(
         `${baseUrl}/movie/top_rated?language=en-US&page=1`
       );
@@ -211,6 +210,11 @@ export default {
       this.movies = await this.fetchCategory(
         `${baseUrl}/movie/top_rated?include_adult=false&include_video=false&language=en-US&page=1&sort_by=popularity.desc`
       );
+
+      var searchFilters = localStorage.getItem("searchFilters");
+      if (searchFilters.length > 0) {
+        localStorage.removeItem("searchFilters");
+      }
     },
 
     // Navigation

--- a/pages/searchResults.vue
+++ b/pages/searchResults.vue
@@ -115,6 +115,26 @@ export default {
     };
   },
   methods: {
+    saveFilters() {
+      const filters = {
+        isSerie: this.isSerie,
+        searchTerm: this.searchTerm,
+      };
+
+      localStorage.setItem("searchFilters", JSON.stringify(filters));
+    },
+    loadFilters() {
+      const filtersFromLocalStorage = JSON.parse(
+        localStorage.getItem("searchFilters") || "{}"
+      );
+
+      if (filtersFromLocalStorage.hasOwnProperty("isSerie")) {
+        this.isSerie = filtersFromLocalStorage.isSerie;
+      }
+      if (filtersFromLocalStorage.hasOwnProperty("searchTerm")) {
+        this.searchTerm = filtersFromLocalStorage.searchTerm;
+      }
+    },
     addToWatchlist(movie) {
       if (this.isSerie) {
         movie.isSerie = "tv";
@@ -340,6 +360,7 @@ export default {
         }
       }
       this.autocomplete();
+      this.saveFilters();
     },
     getPopularMovies() {
       const url =
@@ -396,14 +417,26 @@ export default {
         .then((json) => (this.categories = json.genres))
         .catch((err) => console.error("error:" + err));
     },
+    initializeFunction() {
+      this.getPopularMovies();
+      if (screen.width < 450) {
+        this.marginFromTop = "margin-top: 0px";
+      }
+      this.getCategories();
+      this.getSeriesCategories();
+      this.loadFilters();
+    },
   },
   created() {
-    this.getPopularMovies();
-    if (screen.width < 450) {
-      this.marginFromTop = "margin-top: 0px";
+    if (
+      localStorage.getItem("searchFilters") &&
+      localStorage.getItem("searchFilters").length > 0
+    ) {
+      this.loadFilters();
+      this.search(1);
+    } else {
+      this.initializeFunction();
     }
-    this.getCategories();
-    this.getSeriesCategories();
   },
 };
 </script>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search filters (type and term) are now saved and restored between visits.
  * On returning to the search page, saved filters are auto-loaded and a search runs automatically.
  * Filters are consistently saved after searches and chip-based actions.

* **Bug Fixes**
  * Prevents stale search filters from affecting the home experience by clearing outdated saved filters during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->